### PR TITLE
Detect offset for video_id field rather than just assuming the field before slug

### DIFF
--- a/yt_dlp_plugins/extractor/htv.py
+++ b/yt_dlp_plugins/extractor/htv.py
@@ -53,7 +53,14 @@ class HanimeTVIE(InfoExtractor):
 
         page = self._download_webpage(url, slug)
         title = self._search_regex(r'<h1 class="tv-title">([^<]+)', page, "title")
-        video_id = self._search_regex(rf'(\d+)\s*,\s*"{slug}"', page, "video id")
+
+        # Grab the letter used to indicate which field is the id
+        id_offset = ord(self._search_regex(rf'hentai_video:{{id:([^,]+),', page, "id offset"))-ord('a')
+
+        # Grab the fields and extract the video_id from the offset field
+        rawfields = self._search_regex(rf'\((null,.*,"{slug}",.*)\)\);', page, "fields")
+        fields = list(csv.reader(rawfields.splitlines()))
+        video_id = fields[0][id_offset]
 
         # NOTE This script is unlikely to change, so better cache it.
         if not self._script:


### PR DESCRIPTION
Some videos were failing as the fields are presented in various orders to obfuscate their functions.

This code pulls the letter code used for the id field and then extracts that field number from the function call.

I'm not sure how robust this is, or if it's the best way to do this, but it worked across the various videos I tried.